### PR TITLE
__repr__ for Registries

### DIFF
--- a/lnschema_bionty/__init__.py
+++ b/lnschema_bionty/__init__.py
@@ -4,7 +4,7 @@ Since version 0.40.0, `bionty` replaces `lnschema-bionty` as the user-facing pac
 
 """
 
-__version__ = "0.41.5"  # Denote a release candidate of version 0.1.0 with 0.1rc1
+__version__ = "0.41.6"  # Denote a release candidate of version 0.1.0 with 0.1rc1
 
 from lamindb_setup import _check_instance_setup
 

--- a/lnschema_bionty/_bionty.py
+++ b/lnschema_bionty/_bionty.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import Dict, Optional, Union
-
 import bionty_base
 from django.core.exceptions import ObjectDoesNotExist
 from lamin_utils import logger

--- a/lnschema_bionty/core/_settings.py
+++ b/lnschema_bionty/core/_settings.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import Optional, Union
-
 from lamin_utils import logger
 
 from lnschema_bionty.models import Organism

--- a/lnschema_bionty/models.py
+++ b/lnschema_bionty/models.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import List, Optional, Tuple, Union, overload
+from typing import List, Tuple, overload
 
 import bionty_base
 import numpy as np
@@ -90,6 +90,21 @@ class BioRegistry(Registry, HasParents, CanValidate):
                 self._parents = parents
 
         super().__init__(*args, **kwargs)
+
+    def __repr__(self) -> str:
+        # fmt: off
+        representation = (
+            f"Private registry\n"
+            f"Entity: {self.__class__.__name__}\n"
+            f"📖 .df(): reference table\n"
+            f"🔎 .lookup(): autocompletion of terms\n"
+            f"🎯 .search(): free text search of terms\n"
+            f"✅ .validate(): strictly validate values\n"
+            f"🧐 .inspect(): full inspection of values\n"
+            f"👽 .standardize(): convert to standardized names"
+        )
+        # fmt: on
+        return representation
 
     @classmethod
     def public(


### PR DESCRIPTION
Fix #226 

I opted to keep the emojis because they serve as a nice divider.
We could also use a `_______` or something to differentiate the "header" and the "methods". For now I'll keep it consistent.